### PR TITLE
Add 'time' to top level of HTTP request

### DIFF
--- a/ml_gen.py
+++ b/ml_gen.py
@@ -143,6 +143,7 @@ def send_batch_to_hec(events, target, token, index, sourcetype):
                     "index": index,
                     "sourcetype": sourcetype,
                     "source": "ml_gen.py",
+                    "time": event.get("time"),
                 }
             )
             for event in events


### PR DESCRIPTION
I needed this for Splunk to pick up the times correctly, as per docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector .