### PR TITLE
Added missing attributes to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       - ./run_backfill.sh:/run_backfill.sh
       - ./run_normal.sh:/run_normal.sh
       - ./run_gen_lower_outlier.sh:/run_gen_lower_outlier.sh
-      - ./run_gen_lower_outlier.sh:/run_gen_lower_outlier.sh
+      - ./run_gen_upper_outlier.sh:/run_gen_upper_outlier.sh
+      - ./ml_gen.py:/ml_gen.py
     #command: bash /run_normal.sh
     command: tail -f /dev/null
     build:


### PR DESCRIPTION
Identified a potential mistake in docker-compose.yml, with run_gen_lower_outlier.sh being listed twice, rather than both the run_gen_lower_outlier.sh and run_gen_upper_outlier.sh being included. Also noticed that ml_gen.py was missing.